### PR TITLE
skip idempotence

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,3 +6,7 @@
     owner: "root"
     group: "root"
     mode: '0644'
+  tags:
+    # the sorting of interfaces and mounts
+    # is not idempotent
+    - molecule-idempotence-notest


### PR DESCRIPTION
the sorting of mounts and interfaces can not be controlled